### PR TITLE
Privacy-preserving aggregate storage + macOS auto-start LaunchAgent

### DIFF
--- a/.agents/commits/2026-06-08_aggregate-count-storage.md
+++ b/.agents/commits/2026-06-08_aggregate-count-storage.md
@@ -1,0 +1,145 @@
+## Goal
+
+Make continuous background logging safe to leave running by changing the default
+storage model from exact per-keystroke rows to **aggregate counts grouped into
+time buckets**, so the exact typed sequence (passwords included) is never written
+to disk. Add the bigram counting that the user wanted but which the old
+view-based design could not provide once per-keystroke rows go away.
+
+The user's stated plan was "round each keystroke's timestamp to the nearest 10
+minutes." The important correction baked into this commit: rounding the timestamp
+alone protects nothing, because one row per keystroke remains recoverable in
+insertion (`rowid`) order regardless of its timestamp. The real protection is
+collapsing keystrokes into per-bucket counts, which destroys ordering.
+
+## Files Changed And Why
+
+### `key_logger.py`
+
+- **New default sink: aggregate count tables.** `key_counts_agg(bucket_utc,
+  key_code, count)` and `bigram_counts_agg(bucket_utc, key1, key2, count)` are
+  created and incremented via SQLite UPSERT (`ON CONFLICT ... DO UPDATE SET count
+  = count + 1`). An optional `trigram_counts_agg` is created only with
+  `--trigrams`. The composite PRIMARY KEY on each table is the UPSERT conflict
+  target.
+- **Tables are `WITHOUT ROWID` — load-bearing for privacy, not an optimization.**
+  An ordinary SQLite table keeps an implicit `rowid` in insertion order, so
+  reading the aggregate rows `ORDER BY rowid` would replay the order keys (and
+  bigrams) were first seen in a bucket — and the bigram rows alone trivially
+  reconstruct a quiet-bucket password (`(p,a),(a,s),(s,s),(s,w),... → password`).
+  `WITHOUT ROWID` removes that column entirely; rows exist only in PRIMARY KEY
+  (lexicographic) order, so nothing about typing order survives. Without this,
+  aggregation would *not* actually destroy ordering, defeating the whole point.
+- **Capture-time n-grams.** Bigrams (and optional trigrams) can no longer be
+  rebuilt from stored rows, so `update_ngram_chain()` forms them live from the
+  last one/two logged "plain" entries. The chain resets across modifier combos,
+  pauses longer than `BIGRAM_IDLE_RESET_SECONDS`, and bucket boundaries, so each
+  stored bigram is internally consistent (never spans two buckets) and unrelated
+  typing sessions aren't stitched together.
+- **`bucket_label()`** — new top-level pure helper that floors a UTC datetime to
+  its bucket start and returns an ISO string. Floor (not round-to-nearest) keeps
+  buckets contiguous and each event in exactly one bucket. Lives with the other
+  pure helpers for easy testing.
+- **Views rewritten** to read the aggregate tables (`SUM(count)` instead of
+  `count(*)`/`LAG()`), preserving the same output columns (`count`, `frequency`,
+  `cumulative_frequency`) so existing analysis queries still work.
+- **New flags:** `--counts/--no-counts` (default follows `--sqlite`),
+  `--raw-events/--no-raw-events` (opt-in exact per-keystroke `key_log`, off),
+  `--trigrams/--no-trigrams` (off), `--bucket-minutes` (default 10).
+  `--sqlite/--no-sqlite` is now the master DB switch; `Config.uses_sqlite`
+  derives whether any DB sink is active. `parse_args()` validates bucket size,
+  that DB sinks require SQLite, that trigrams require counts, and that at least
+  one output sink is enabled.
+- **`datetime.utcnow()` → `datetime.now(timezone.utc)`** in both timestamp paths,
+  fixing the Python 3.12+ deprecation while keeping the stored ISO format
+  unchanged (no `+00:00` suffix).
+
+### `README.md`
+
+Rewrote the Output Storage section to describe aggregation as the default and the
+privacy reasoning (timestamp-rounding alone is insufficient; bigram/trigram
+tradeoff; Secure Input Mode coverage), updated the SQLite-views and batching
+notes, added usage examples for the new flags, and expanded the Audit Checklist
+and Local Data Safety notes.
+
+## Behavior Changes
+
+- Default storage is now per-bucket counts, not per-keystroke rows. The default
+  database has no recoverable sequence and no `key_log` table.
+- Bigrams are counted at capture time and exposed through the same
+  `bigram_counts` view; trigrams require `--trigrams`.
+- `--raw-events` restores the old exact per-keystroke `key_log` table (opt-in).
+- A literally-typed `+` (Shift+=) is now counted in bigrams; the old views'
+  `NOT LIKE '%+%'` filter wrongly excluded it. Combo entries (`<ctrl> + c`) still
+  break the n-gram chain, matching the old intent.
+- Startup config summary reports `counts`, `bucket_minutes`, `trigrams`,
+  `raw_events`, and `full_events`.
+
+## Approach
+
+Keep aggregation a shallow extension of the existing `log()` call site (which
+already fires exactly once per logged non-modifier keystroke) and reuse the
+already-computed `log_entry` as the n-gram unit, so the new counts match the
+granularity the old views operated on. Keep all new invasive capabilities
+(trigrams, exact rows) opt-in and off, consistent with the project's benign
+ethos — the only default that changed is toward *more* privacy, which the user
+explicitly requested.
+
+## Alternatives Considered
+
+### Round the timestamp but keep one row per keystroke
+Rejected: does not protect anything; the sequence is still recoverable via
+`rowid` order. This was the user's initial idea and the main thing this commit
+corrects.
+
+### Keep per-keystroke rows and run a periodic rollup/prune job
+Rejected: still writes exact keystrokes to disk (a leak window), and needs a
+scheduler or timer — more moving parts, less auditable.
+
+### One wide n-gram table with an order column / nullable keys
+Rejected: messier PRIMARY KEY (SQLite treats NULLs as distinct) and uglier views.
+Three explicit tables are more auditable.
+
+### Purge count-1 n-grams at bucket close (extra hardening)
+Considered and explicitly declined by the user for now; left as a documented
+future option. It would better protect a one-off secret typed in a quiet window
+but biases rare-key stats and adds runtime DML.
+
+## Assumptions
+
+- SQLite ≥ 3.24 (UPSERT). The `keylogger` env ships 3.53; a startup guard errors
+  clearly if an older engine is ever used with counts on.
+- The user wants bigram frequency for layout work and accepts the residual,
+  situational bigram-reconstruction risk (trigrams left off).
+
+## Shortcuts Or Tradeoffs
+
+- Bigrams that straddle a bucket boundary are dropped rather than attributed to
+  one side — at most one lost pair per boundary crossing, negligible for
+  frequency study, in exchange for internally consistent per-bucket rows.
+- Old data is not migrated (see Known Limitations).
+- A keystroke now issues up to a few writes (unigram + bigram [+ trigram]), so
+  commits batch slightly more often. Harmless.
+
+## Known Limitations
+
+- Opening a pre-existing old-schema `key_log.sqlite` leaves the old table and
+  rows untouched but does not migrate them into the aggregate tables; the views
+  reflect only newly captured data. A manual `INSERT ... SELECT` backfill is
+  possible but intentionally not run automatically.
+- In raw-only mode (`--no-counts --raw-events`) the convenience views are not
+  created; that mode is for users who query the raw table directly.
+- Residual bigram-reconstruction risk remains for a short secret typed in an
+  otherwise-quiet bucket; mitigated by bucket mixing, chain breaks, and Secure
+  Input Mode, but not eliminated.
+
+## Key Decisions
+
+- Aggregate counts are the default; exact per-keystroke logging and trigrams are
+  opt-in and off.
+- Aggregate tables are `WITHOUT ROWID` so insertion order (and thus typing
+  order) is not recoverable — counts are all that remain.
+- Bigrams are computed at capture time; views read the aggregate tables.
+- `--sqlite` becomes the master DB switch; counts default to following it.
+- Floor-to-bucket timestamps; break n-gram chains across combos, pauses, and
+  bucket boundaries.

--- a/.agents/commits/2026-06-08_macos-launch-agent.md
+++ b/.agents/commits/2026-06-08_macos-launch-agent.md
@@ -1,0 +1,139 @@
+## Goal
+
+Let the logger start automatically at login so it can accumulate key/bigram
+frequency stats continuously, without the user having to remember to launch it.
+Do this without weakening the project's benign/auditable posture: no new
+capability, no change to defaults, and no `launchctl`/`subprocess` code added to
+`key_logger.py` itself.
+
+## Files Changed And Why
+
+### `launchd/local.benign-key-logger.plist.template` (new)
+
+The LaunchAgent definition, with `__PLACEHOLDER__`-style path tokens so the repo
+holds no machine-specific absolute paths. Notable, deliberate choices encoded in
+it:
+
+- **User LaunchAgent, not a LaunchDaemon.** It loads into the `gui/<uid>` domain
+  (the logged-in session). A daemon runs outside the user's GUI session and would
+  see no keyboard events, so an agent is the only correct option here.
+- **Absolute `--sqlite-file` plus `WorkingDirectory`.** `launchd` runs with
+  `cwd=/`, and the script's `--sqlite-file` default is the *relative*
+  `key_log.sqlite`. Left alone, the DB would be written to `/key_log.sqlite`. The
+  agent passes an absolute DB path; `WorkingDirectory` is a backup for the same
+  reason.
+- **Privacy-preserving invocation only.** `ProgramArguments` is just the
+  interpreter, the script, and `--sqlite-file <abs path>`. No `--stdout`,
+  `--raw-events`, `--trigrams`, or `--file`, so the background run uses the same
+  aggregate-counts-only default as a foreground run.
+- **`RunAtLoad` = true** (start at login); **`KeepAlive` = { Crashed = true }**
+  (restart on abnormal exit, not on clean logout). A comment notes this does
+  *not* rescue the silent no-permission case (see below), since that is not a
+  crash.
+- **`StandardErrorPath`/`StandardOutPath`** under `~/Library/Logs/benign-key-logger/`
+  capture the script's startup config summary and "starting to listen" line
+  (logged to stderr). These hold only status lines, never keystrokes (stdout echo
+  is off).
+
+### `launchd/install.sh` (new)
+
+Generates the concrete plist from the template (path substitution via `sed`),
+`plutil -lint`s it, and loads it with the modern
+`launchctl bootstrap gui/$(id -u)` (booting out any prior copy first, so re-runs
+are idempotent). It then prints the one thing it cannot do for the user: the
+exact **resolved real interpreter path** to add under Input Monitoring. The real
+path is computed with `python -c 'os.path.realpath(sys.executable)'` because TCC
+attaches the grant to the resolved binary (`.../bin/python3.11`), not the
+`python` symlink the agent invokes. Interpreter location is overridable via
+`PYTHON_OVERRIDE`.
+
+### `launchd/uninstall.sh` (new)
+
+`launchctl bootout` + remove the installed plist. Leaves captured data untouched
+and does not alter System Settings; reminds the user how to revoke the grant.
+
+### `README.md`
+
+New "Running automatically at login (macOS LaunchAgent)" subsection under Usage
+(agent-vs-daemon rationale, the manual Input-Monitoring grant, the silent-failure
+warning, install/verify/uninstall commands, and the conda-rebuild caveat). Three
+Audit Checklist bullets: auto-start is opt-in and self-contained; the launch
+tooling is readable plain text with no network and a bounded set of write
+targets; and `key_logger.py` is unchanged by this feature.
+
+## Behavior Changes
+
+- No change to `key_logger.py` and no change to any default. Nothing runs
+  automatically unless the user explicitly runs `sh launchd/install.sh`.
+- Once installed, the same script runs at login with counts-only storage, writing
+  to the repo's `key_log.sqlite` and status logs to `~/Library/Logs/benign-key-logger/`.
+
+## Approach
+
+Keep all auto-start machinery as separate, auditable ops files in `launchd/` and
+leave the logger pristine. Reuse the existing privacy-preserving CLI defaults
+rather than adding any new flag or mode. Make the install/uninstall path
+idempotent and self-describing, and put the unavoidable manual step (granting the
+interpreter keyboard access) front and centre in both the installer output and
+the README, because on a `launchd`-started process macOS neither inherits the
+Terminal grant nor prompts, and pynput fails silently without it.
+
+## Alternatives Considered
+
+### Add `--install-launch-agent` to `key_logger.py`
+Rejected: it would introduce `subprocess`/`launchctl` into the single auditable
+file, eroding the "no shelling out" property the benign audit relies on, and push
+the script to write outside its data path.
+
+### LaunchDaemon instead of LaunchAgent
+Rejected: a daemon runs outside the user's GUI login session and would capture no
+keystrokes; it also needs root. An agent in `gui/<uid>` is the correct scope.
+
+### Minimal signed `.app` bundle for a stable TCC identity
+Considered and documented as a more robust option (it survives conda env
+rebuilds because the grant binds to a stable bundle id rather than the
+interpreter binary). Not built: it adds an `Info.plist` + code-signing step, and
+for a single user a one-time re-grant after an env rebuild is simpler. Left as a
+documented future hardening.
+
+### Docs-only manual install (no scripts)
+Rejected in favor of the turnkey scripts at the user's request; the scripts are
+short and readable, and the manual `launchctl` commands are still shown in the
+README for anyone who prefers them.
+
+## Assumptions
+
+- The conda `keylogger` env interpreter is at
+  `~/opt/miniconda3/envs/keylogger/bin/python` (overridable via `PYTHON_OVERRIDE`).
+- The user will manually grant Input Monitoring (and, if needed, Accessibility)
+  to the resolved interpreter binary — this cannot be automated and is required
+  for any capture at all.
+- Paths involved contain no `|` character (the `sed` substitution delimiter);
+  true for the standard home/repo locations here.
+
+## Shortcuts Or Tradeoffs
+
+- The label and default interpreter path are constants near the top of the
+  scripts; changing them is a one-line edit rather than a CLI flag.
+- `KeepAlive` restarts only on crash, so a clean but unwanted exit would stay
+  down until next login. This is intentional to avoid fighting manual stops, and
+  is irrelevant to the silent-permission case anyway.
+
+## Known Limitations
+
+- **Silent failure without permission:** if Input Monitoring is not granted, the
+  agent runs but logs nothing and does not error; `KeepAlive` cannot detect this.
+  The README's verification step (watch the DB grow) is the intended check.
+- **Conda env rebuilds invalidate the grant:** macOS binds the permission to the
+  resolved `python3.11` binary; recreating the env requires re-granting once.
+- macOS-only, like the rest of the project's OS-specific guidance.
+
+## Key Decisions
+
+- A user LaunchAgent in `gui/<uid>`, never a LaunchDaemon.
+- `key_logger.py` is untouched; all launch tooling lives in `launchd/`.
+- Absolute `--sqlite-file` (+ `WorkingDirectory`) so the DB never lands in `/`.
+- Reuse the counts-only privacy defaults; introduce no new invasive flag.
+- Grant the resolved interpreter binary directly; `.app`-bundle identity is
+  documented but not built.
+- Modern `launchctl bootstrap`/`bootout`; idempotent install.

--- a/.agents/commits/2026-06-20_generate-launchagent-plist-with-plutil.md
+++ b/.agents/commits/2026-06-20_generate-launchagent-plist-with-plutil.md
@@ -1,0 +1,96 @@
+## Goal
+
+Make `launchd/install.sh` generate the LaunchAgent plist robustly for any path.
+The installer filled the template with raw `sed` substitution, which breaks when
+a resolved path (interpreter, repo, DB, or log dir) contains characters that are
+significant to XML (`&` `<` `>` `"`) or to `sed` (`|` `\` `&`): the result is
+invalid XML or a mis-substituted value. Switch to the structured `plutil` tool
+already used to lint the file. (Addresses upstream PR review feedback.)
+
+## Files Changed And Why
+
+### `launchd/install.sh`
+
+- Replaced the `sed` substitution block with `cp template → dest` followed by
+  `plutil -replace` calls. `plutil` writes through the property-list serializer,
+  so values are stored literally and any XML-significant character is escaped
+  correctly — no manual escaping, no delimiter hazard.
+  - Scalars by key: `Label`, `WorkingDirectory`, `StandardOutPath`,
+    `StandardErrorPath` via `plutil -replace <key> -string "$VALUE"`.
+  - The entire `ProgramArguments` array is replaced in one shot with
+    `plutil -replace ProgramArguments -json "$PA_JSON"`, where `$PA_JSON` is
+    built by the already-resolved interpreter
+    (`"$PYTHON" -c 'import json,sys; print(json.dumps([...]))'`). Building the
+    JSON with `json.dumps` escapes every argv element (including lone
+    backslashes and quotes) safely.
+- Added a placeholder guard: after substitution, `grep -q '__[A-Z_]*__'` fails
+  the install if any `__TOKEN__` survived, because a wrong-but-valid plist still
+  passes `plutil -lint`. `set -eu` and the existing `plutil -lint` are retained.
+
+## Behavior Changes
+
+- The installed plist is now correct for paths containing `&`, `<`, `>`, `"`,
+  `|`, or `\`; previously such a path produced invalid XML or a wrong value.
+- The generated plist no longer carries the template's explanatory XML comments:
+  `plutil` rewrites the file canonically and drops comments. This only affects
+  the installed copy (which already says "do not hand-edit"); the template keeps
+  its comments and remains the documented source of truth.
+- No change to `key_logger.py`, to `uninstall.sh`, or to what the agent runs.
+
+## Approach
+
+Prefer the structured macOS-native tool (`plutil`, already a dependency of this
+script via `-lint`) over hand-rolled escaping. Replace scalars by key path and
+the array as a whole — never by element index — and build the array's JSON with
+the interpreter that is already resolved and validated earlier in the script, so
+no second utility and no shell-quoting minefield is introduced.
+
+## Alternatives Considered
+
+### Per-index `plutil -replace ProgramArguments.<N>`
+Rejected: on macOS this **inserts** at index N rather than overwriting it.
+Replacing indices 0, 1, 3 of the 4-element template array yields a 7-element
+array with a stray literal `__DB__` — and `plutil -lint` still reports OK, so the
+breakage would ship silently. Replacing the whole array via `-json` avoids this.
+
+### `/usr/libexec/PlistBuddy -c "Set :ProgramArguments:N ..."`
+Rejected: PlistBuddy's `-c` argument does its own quote/backslash parsing and
+silently drops a lone `\` from a value. It also adds a second tool. The
+`plutil -replace -json` route has neither problem.
+
+### Escape values, keep `sed`
+Rejected: correct double-escaping (XML then `sed`) in POSIX `sh` is fiddly and
+error-prone, and the reviewer's preferred option was a structured plist tool.
+
+## Assumptions
+
+- `plutil` and a working `$PYTHON` are available — both already required by this
+  script (it lints with `plutil` and resolves the interpreter's real path with
+  `$PYTHON -c`), so no new dependency.
+- The template defines `Label`, `WorkingDirectory`, `StandardOutPath`,
+  `StandardErrorPath`, and a 4-element `ProgramArguments`
+  (`[python, script, --sqlite-file, db]`); the install script's key paths and
+  JSON layout track that structure.
+
+## Shortcuts Or Tradeoffs
+
+- `ProgramArguments` is rebuilt wholesale rather than edited element-by-element,
+  which couples the install script to the array's intended shape — but that is
+  precisely what the per-index insert bug forces, and the layout lives in one
+  place in both files.
+- The installed plist loses the template's comments (see Behavior Changes); an
+  acceptable cost for correct, injection-safe generation.
+
+## Known Limitations
+
+- `plutil -lint` validates XML well-formedness, not semantic correctness, so it
+  cannot by itself catch a wrong-but-valid plist; the placeholder guard covers
+  the most likely such mistake (an unsubstituted token).
+- macOS-only, like the rest of the `launchd/` tooling.
+
+## Key Decisions
+
+- Generate the plist with structured `plutil`, never raw `sed`.
+- Replace `ProgramArguments` as a whole via `-json` (built with `json.dumps`),
+  never by element index (which inserts, not overwrites).
+- Add a hard placeholder guard before `plutil -lint`.

--- a/.agents/commits/2026-06-20_warn-about-all-legacy-sensitive-tables.md
+++ b/.agents/commits/2026-06-20_warn-about-all-legacy-sensitive-tables.md
@@ -1,0 +1,96 @@
+## Goal
+
+Make the counts-only privacy default honest for users with *existing* databases.
+The startup legacy-data warning previously only flagged a leftover `key_log`
+table, but two other sensitive sinks can sit in the same file and go unmentioned:
+`full_key_log` (exact key up/down events + timestamps, from a prior
+`--full-events` run) and `trigram_counts_agg` (higher reconstruction risk than
+the default bigrams, from a prior `--trigrams` run). Reopening such a DB under
+the aggregate defaults leaves that exact/higher-risk history on disk silently.
+Warn about all three. (Addresses upstream PR review feedback.)
+
+## Files Changed And Why
+
+### `key_logger.py`
+
+- Replaced `warn_if_legacy_key_log_table()` with `warn_about_legacy_sensitive_tables()`,
+  which sweeps a small table of `(table_name, is_intentional_flag, what_it_leaks)`:
+  `key_log` ↔ `send_raw_events_to_sqlite`, `full_key_log` ↔
+  `send_all_events_to_sqlite`, `trigram_counts_agg` ↔ `send_trigram_counts`. For
+  each table whose opt-in flag is OFF and which exists in `sqlite_master`, it logs
+  a warning naming the table, what it leaks, and the exact `DROP TABLE <name>;` to
+  remove it. No migration, no deletion — the user stays in control of their data.
+- **Dropped the previous `if not send_counts_to_sqlite: return` gate.** Each
+  table is now gated only on its own flag. The method is only reached when a
+  SQLite sink is active (`run()` calls `setup_sqlite_database()` only when
+  `config.uses_sqlite`), so gating on counts mode was both unnecessary and wrong:
+  under `--no-counts --raw-events`, a leftover `full_key_log`/`trigram_counts_agg`
+  would have been skipped — exactly the blind spot the review flagged.
+- Added `sqlite_table_exists(name)`, a parameterized existence check, so table
+  names are bound as parameters rather than spliced into the SQL string.
+- Updated the call site in `setup_sqlite_database()` to the new method name.
+
+### `README.md`
+
+Added one Audit Checklist bullet: startup warns when the DB still holds a
+`key_log`, `full_key_log`, or `trigram_counts_agg` table the current run isn't
+writing, and prints the exact `DROP TABLE …;` rather than migrating or deleting
+anything.
+
+## Behavior Changes
+
+- On startup with a SQLite sink, the logger now warns about every pre-existing
+  sensitive table not active this run, not just `key_log`.
+- Fresh databases and runs that legitimately enable a table (its flag ON) are
+  unaffected — no warning for an intentional table.
+- No table is ever migrated or dropped automatically; behavior is warn-only.
+
+## Approach
+
+Keep the existing warn-only, user-in-control philosophy and the single-message
+format, and generalize from one hard-coded table to a data-driven list keyed by
+each sink's own opt-in flag. Tailor each message to what that table actually
+leaks (the `*_log` tables hold exact sequences; `trigram_counts_agg` is aggregate
+counts but a higher reconstruction risk than the default bigrams).
+
+## Alternatives Considered
+
+### Keep the counts-mode gate and just add `full_key_log`
+Rejected: it would still miss leftover sensitive tables under `--no-counts
+--raw-events`, which is precisely the case the reviewer raised. Per-table flag
+gating is both simpler and strictly more correct.
+
+### Auto-drop or migrate the legacy tables
+Rejected: silently deleting a user's data is exactly the kind of surprise this
+project avoids. Warn and hand the user the precise `DROP TABLE` instead.
+
+### One combined warning listing all leftover tables
+Rejected: a separate line per table gives each its own copy-pasteable
+`DROP TABLE <name>;` and reads clearly in the log.
+
+## Assumptions
+
+- The three named tables are the only sinks that retain exact-sequence or
+  higher-risk history; `key_counts_agg`/`bigram_counts_agg` are the always-on
+  aggregate defaults and are not flagged.
+- The method runs only when a SQLite connection is open (guaranteed by
+  `config.uses_sqlite` gating the call site).
+
+## Shortcuts Or Tradeoffs
+
+- The warning fires every run while a flagged table remains, which is mildly
+  repetitive but is the point — it keeps nagging until the user drops the data or
+  re-enables the corresponding mode.
+
+## Known Limitations
+
+- Detection is by table name only; a user who renamed a sensitive table won't be
+  warned.
+- Still warn-only by design: leftover data persists until the user runs the
+  printed `DROP TABLE`.
+
+## Key Decisions
+
+- Gate each sensitive table on its own opt-in flag, not on counts mode.
+- Warn-only, never migrate or delete; print the exact `DROP TABLE <name>;`.
+- Parameterized `sqlite_table_exists()` helper instead of inlining table names.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,51 @@ Some common examples:
 
 You could add execution permissions to the file (`chmod +x key_logger.py`) and then run it like a script (`./key_logger.py`), since it does have the Python shebang at the top; however, in the spirit of being *benign*, I don't like the idea of making the file executable, even though I know it's not an EXE, but ¯\\\_(ツ)\_/¯.
 
+### Running automatically at login (macOS LaunchAgent)
+
+If you want the logger to start by itself every time you log in — handy for building up usage stats over weeks without remembering to launch it — there is a ready-made macOS LaunchAgent in the `launchd/` folder. It runs the exact same script with the exact same privacy-preserving defaults (aggregate counts only — no stdout echo, no raw per-keystroke rows, no trigrams), so leaving it running is no more revealing than a normal foreground run.
+
+A few things are worth understanding before you install it:
+
+- **It's a LaunchAgent, not a LaunchDaemon.** It loads into your logged-in GUI session (`gui/<uid>`). A daemon runs outside your session and would capture nothing, so this is deliberate.
+- **You must grant keyboard access to the Python interpreter itself.** When `launchd` starts the script there is no Terminal in the picture, so any Accessibility/Input Monitoring permission you granted to Terminal does **not** carry over, and macOS will **not** pop up a prompt. You add the interpreter manually (the installer prints the exact path). Grant it **Input Monitoring**, and if events still don't show up, also add it to **Accessibility**.
+- **Without that permission it fails silently.** `pynput` keeps running but receives zero events — it does not error or crash — so the only reliable way to confirm it works is to check that the database is growing.
+
+To install and load it:
+
+```sh
+sh launchd/install.sh
+```
+
+That script fills the absolute paths into `launchd/local.benign-key-logger.plist.template`, writes the result to `~/Library/LaunchAgents/local.benign-key-logger.plist`, validates it with `plutil -lint`, and loads it with `launchctl bootstrap`. The database goes to `key_log.sqlite` in this repo folder and operational logs to `~/Library/Logs/benign-key-logger/`. It does not modify `key_logger.py` and does not change any permissions for you. (If your interpreter isn't at the default conda path, run it as `PYTHON_OVERRIDE=/path/to/python sh launchd/install.sh`.)
+
+**What you'll need to set for your own machine.** The installer auto-detects the repo location and writes the database and logs relative to it, so the only thing most people must supply is the **Python interpreter that has `pynput` installed**. It defaults to `$HOME/opt/miniconda3/envs/keylogger/bin/python`; if yours is elsewhere, pass it explicitly with `PYTHON_OVERRIDE=/path/to/your/python sh launchd/install.sh`, and the installer prints the exact resolved binary path you must grant in the next step. To use a different agent name, change the `LABEL` near the top of `launchd/install.sh` and `launchd/uninstall.sh` and rename `launchd/<label>.plist.template` to match.
+
+Then grant the permission the installer printed, e.g.:
+
+> System Settings → Privacy & Security → **Input Monitoring** → **+** → Cmd+Shift+G → paste the interpreter path that `install.sh` printed (e.g. `/Users/<your-username>/miniconda3/envs/keylogger/bin/python3.11`) → enable the toggle.
+
+To confirm it's actually capturing:
+
+```sh
+launchctl print "gui/$(id -u)/local.benign-key-logger"   # shows state and last exit status
+tail -n 20 ~/Library/Logs/benign-key-logger/launchd.err.log       # expect "starting to listen for keyboard events"
+sqlite3 key_log.sqlite "SELECT COALESCE(SUM(count),0) FROM key_counts_agg;"   # type a bit; this should rise
+```
+
+To stop and remove it:
+
+```sh
+sh launchd/uninstall.sh
+```
+
+That unloads the agent and deletes the installed plist; it leaves your captured data alone and does not touch System Settings (revoke the interpreter's Input Monitoring grant yourself if you want a clean slate).
+
+Two caveats:
+
+- **Changing how it runs:** edit `launchd/local.benign-key-logger.plist.template` (for example to add a flag such as `--bucket-minutes 30`) and re-run `sh launchd/install.sh`; it re-installs in place.
+- **Rebuilding the conda env may break the grant.** macOS ties the permission to the resolved real binary (`.../bin/python3.11`); if you recreate the `keylogger` env, that binary changes and you'll have to grant Input Monitoring once more. (For a rock-stable identity you could wrap the script in a small signed `.app` bundle, but for a single user the one-time re-grant is simpler.)
+
 ### Local Data Safety
 
 This tool does not send your data anywhere, but the files it writes are still sensitive and should remain owner-only on disk. The program enforces that automatically for the files it creates and warns when it has to tighten existing permissions, which helps reduce local disclosure risk on shared machines or under a permissive `umask`. The default aggregate-count storage further reduces sensitivity by never recording your exact keystroke sequence — but note that the opt-in `--raw-events` and `--file` modes *do* record exact sequences, so treat those outputs with extra care.
@@ -136,6 +181,9 @@ If you want a quick trust checklist before running it, here are the main things 
 - Full event capture is opt-in: `--full-events` enables the more verbose key up/down table in SQLite.
 - WAL is opt-in: `--wal` enables SQLite write-ahead logging for concurrent inspection.
 - Password handling depends on the OS: on macOS, secure input mode usually suppresses logging in password fields, but that behavior is provided by the OS, not by custom filtering in this script.
+- Auto-start is opt-in and self-contained: the `launchd/` LaunchAgent only runs if you install it with `sh launchd/install.sh`. It runs the same script with the same default counts-only settings, adds no flag that records exact sequences, and is removed with `sh launchd/uninstall.sh`.
+- The launch tooling is plain text you can read: `launchd/local.benign-key-logger.plist.template` and the install/uninstall scripts contain no network calls and write only to `~/Library/LaunchAgents/`, the repo's `key_log.sqlite`, and `~/Library/Logs/benign-key-logger/`.
+- The logger itself is unchanged by auto-start: no `launchctl`/`subprocess` was added to `key_logger.py`; all launch tooling lives in `launchd/`.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ If you want a quick trust checklist before running it, here are the main things 
 - Plaintext timestamps are on by default: `--no-file-timestamps` reverts the plaintext file log to bare key entries.
 - Output files are owner-only: the logger creates or tightens log files to `0600`, including SQLite sidecar files when present.
 - Full event capture is opt-in: `--full-events` enables the more verbose key up/down table in SQLite.
+- Leftover sensitive tables are flagged, not silently kept: on startup the logger warns if the database still holds a `key_log`, `full_key_log`, or `trigram_counts_agg` table that the current run isn't writing (e.g. left behind by an earlier `--raw-events`/`--full-events`/`--trigrams` run). It never migrates or deletes that data for you — the warning prints the exact `DROP TABLE …;` to remove it yourself.
 - WAL is opt-in: `--wal` enables SQLite write-ahead logging for concurrent inspection.
 - Password handling depends on the OS: on macOS, secure input mode usually suppresses logging in password fields, but that behavior is provided by the OS, not by custom filtering in this script.
 - Auto-start is opt-in and self-contained: the `launchd/` LaunchAgent only runs if you install it with `sh launchd/install.sh`. It runs the same script with the same default counts-only settings, adds no flag that records exact sequences, and is removed with `sh launchd/uninstall.sh`.

--- a/README.md
+++ b/README.md
@@ -30,18 +30,28 @@ I use this on my Mac, running on Python3 (3.8.1, but I presume any Python3 versi
 
 ### Output Storage
 
-There are two ways to store the output (the key log). In both cases, it's put in a single file in the same directory you're running the script.
+The output goes into a single file in the directory you run the script from. [SQLite](https://sqlite.org/index.html) is the default, and by default it stores **aggregate counts**, not your exact keystrokes.
 
-1. Put every key stroke into a text file, one entry per line
-2. Put every key stroke into a [SQLite](https://sqlite.org/index.html) database
+1. **Aggregate counts in SQLite (default).** Keystrokes are tallied into time buckets (10 minutes by default, `--bucket-minutes` to change). The database keeps one row per `(bucket, key)` and per `(bucket, key1, key2)` bigram, incremented in place. Because only per-bucket counts are stored, the exact sequence you typed — passwords included — is never written to disk and can't be read back out.
+2. **Exact per-keystroke rows in SQLite (opt-in, `--raw-events`).** Restores the old behavior of one row per keystroke, with a precise timestamp, in a `key_log` table. This *does* preserve the exact typed order, so it's off by default; only turn it on if you understand and want that.
+3. **Plaintext text file (opt-in, `--file`).** One entry per line, also the exact sequence. Off by default.
 
-[SQLite](https://sqlite.org/index.html) is the default option. You can swap that or turn both on if you wish. The main storage options are exposed through the command line now instead of requiring you to edit the script.
+You can combine these. The storage options are all exposed through the command line.
+
+#### Why aggregate counts are the default
+
+Rounding timestamps alone would *not* protect you: as long as one row per keystroke exists, the exact sequence is recoverable from the rows' insertion order regardless of the timestamp. The real protection is collapsing keystrokes into counts so the ordering is gone. The aggregate tables are deliberately declared `WITHOUT ROWID`, so they don't even keep SQLite's implicit insertion-order `rowid` — rows live only in sorted key order, leaving counts as the only information present. Two caveats worth knowing:
+
+- **Bigrams** (counted live at capture time, since they can no longer be reconstructed from stored rows) re-introduce adjacency information. For a short secret typed in an otherwise-quiet bucket, bigram counts can partially reconstruct it; in busy/mixed buckets that signal drowns out. To limit this, bigram chains are broken across pauses (more than a couple of seconds) and across bucket boundaries, and **trigrams are off by default** (`--trigrams` to enable — they leak noticeably more).
+- macOS Secure Input Mode already suppresses logging in proper password fields (login, `sudo`, Keychain, most browser password boxes), but not secrets typed into ordinary visible fields, editors, or apps that don't trigger it. Aggregation is what protects the cases Secure Input misses.
+
+A side benefit: aggregation bounds how large the database gets, which matters if you leave the logger running continuously.
 
 Because the output contains sensitive data, the logger now creates its log files with owner-only permissions (`0600`) and will tighten existing log files if they are more permissive. That applies to the text log, the main SQLite file, and the common SQLite sidecar files (`-journal`, `-wal`, and `-shm`) if they exist.
 
-I chose [SQLite](https://sqlite.org/index.html) because the output is a single file that you can delete anytime you want, and it doesn't require any separate database engine. If you're not familiar with it, it's much like putting your data in a text file, one entry per line, but it does so in a structured way that, when you use a program that knows how to read that structure, gives you the power of SQL. The nice thing is that 100% of the data, meta data, etc. is in that one file. And having the entries in a database, does provide some advantages (if you know SQL) when you want to answer questions like "Show me the keys I press in descending order, by frequency?" or "What percentage of key strokes is the space bar?" You can even do some fun stuff like "How fast do I type?" (since timestamps are maintained in the SQLite log), "Do I type more during odd or even hours of the day?", and other, life changing questions-and-answers. A basic version of this is built into the SQLite output file, in the form of predefined views.
+I chose [SQLite](https://sqlite.org/index.html) because the output is a single file that you can delete anytime you want, and it doesn't require any separate database engine. If you're not familiar with it, it's much like putting your data in a text file, but it does so in a structured way that, when you use a program that knows how to read that structure, gives you the power of SQL. The nice thing is that 100% of the data is in that one file. Having the counts in a database makes it easy (if you know SQL) to answer questions like "Show me the keys I press in descending order, by frequency?" or "What percentage of key strokes is the space bar?" The predefined `key_counts` and `bigram_counts` views (and `trigram_counts` with `--trigrams`) summarize exactly this, reading from the aggregate tables. Because the default tables hold only per-bucket counts, questions that need exact per-keystroke timing — like "How fast do I type?" — require the opt-in `--raw-events` mode; coarse time-of-day questions still work off the 10-minute `bucket_utc`.
 
-To avoid paying the full SQLite commit cost on every single keystroke, the logger batches writes and commits them every 50 events or every 5 seconds, whichever comes first, and then performs a final flush on clean shutdown. The event threshold is chosen to be roughly consistent with a fast typist around 100 WPM.
+To avoid paying the full SQLite commit cost on every single keystroke, the logger batches writes and commits them every 50 events or every 5 seconds, whichever comes first, and then performs a final flush on clean shutdown. (In the default count mode a single keystroke issues more than one write — the unigram plus, when applicable, a bigram — so commits happen a little more often than one-per-keystroke would suggest.)
 
 If you want better behavior while inspecting the database at the same time the logger is writing to it, there is also a `--wal` option. It is off by default to keep the file model as simple as possible. If you turn it on, SQLite uses write-ahead logging, which can improve read/write concurrency, but it also means you should expect sidecar files like `-wal` and `-shm` to appear while the database is active.
 
@@ -81,7 +91,11 @@ The help output shows the current defaults, and the program prints a short start
 
 Some common examples:
 
-- Default SQLite logging: `python3 key_logger.py`
+- Default aggregate-count logging (10-minute buckets): `python3 key_logger.py`
+- Aggregate counts with a different bucket size: `python3 key_logger.py --bucket-minutes 30`
+- Also aggregate trigrams (higher reconstruction risk): `python3 key_logger.py --trigrams`
+- Also store exact per-keystroke rows (less private): `python3 key_logger.py --raw-events`
+- Old behavior, exact rows only with no count tables: `python3 key_logger.py --no-counts --raw-events`
 - Physical key logging instead of resulting characters: `python3 key_logger.py --physical-keys`
 - Preserve left/right modifier distinctions: `python3 key_logger.py --modifier-sides`
 - Inspect the logger's internal behavior without echoing captured keys: `python3 key_logger.py --debug`
@@ -100,7 +114,7 @@ You could add execution permissions to the file (`chmod +x key_logger.py`) and t
 
 ### Local Data Safety
 
-This tool does not send your data anywhere, but the files it writes are still sensitive. They contain raw keystrokes and should remain owner-only on disk. The program now enforces that automatically for the files it creates and warns when it has to tighten existing permissions, which helps reduce local disclosure risk on shared machines or under a permissive `umask`.
+This tool does not send your data anywhere, but the files it writes are still sensitive and should remain owner-only on disk. The program enforces that automatically for the files it creates and warns when it has to tighten existing permissions, which helps reduce local disclosure risk on shared machines or under a permissive `umask`. The default aggregate-count storage further reduces sensitivity by never recording your exact keystroke sequence — but note that the opt-in `--raw-events` and `--file` modes *do* record exact sequences, so treat those outputs with extra care.
 
 ### Audit Checklist
 
@@ -111,7 +125,11 @@ If you want a quick trust checklist before running it, here are the main things 
 - Physical key logging is opt-in: `--physical-keys` switches from logging the resulting character to logging the physical key plus modifiers.
 - Left/right modifier distinction is opt-in: `--modifier-sides` keeps modifier sides separate instead of remapping them together.
 - Stdout echo is off by default: keystrokes are only printed to the terminal if you pass `--stdout`.
-- SQLite is on by default: the main log goes to a local SQLite file unless you disable it with `--no-sqlite`.
+- SQLite is on by default: the database is used unless you disable it with `--no-sqlite` (the master switch for all database sinks).
+- Aggregate counts are the default sink: keystrokes are stored as per-bucket counts, not exact sequences, so passwords can't be read back out. Disable with `--no-counts`.
+- Exact per-keystroke logging is opt-in: `--raw-events` restores one-row-per-keystroke storage (the less-private mode); it is off by default.
+- Trigram aggregation is opt-in: `--trigrams` enables trigram counts, which leak more ordering than bigrams; off by default.
+- Bucket size is configurable: `--bucket-minutes` (default 10) controls how coarsely keystroke times are grouped.
 - Plaintext file logging is off by default: the text log is only enabled with `--file`.
 - Plaintext timestamps are on by default: `--no-file-timestamps` reverts the plaintext file log to bare key entries.
 - Output files are owner-only: the logger creates or tightens log files to `0600`, including SQLite sidecar files when present.

--- a/key_logger.py
+++ b/key_logger.py
@@ -779,24 +779,40 @@ class KeyLoggerApp:
       """)
       logging.debug('SQLite full_key_log table created')
 
-  def warn_if_legacy_key_log_table(self):
-    # A pre-existing key_log table holds exact per-keystroke rows from an older
-    # run. In counts-only mode it is neither migrated nor read by the views, so
-    # it just stays in the file and keeps that history reconstructable -- the
-    # privacy default doesn't cover data written before the switch. Warn so the
-    # user can drop it. (With --raw-events the table is intentional, not legacy.)
-    if (not self.config.send_counts_to_sqlite
-        or self.config.send_raw_events_to_sqlite):
-      return
+  def sqlite_table_exists(self, name):
+    # Parameterized existence check so a table name is never spliced into SQL.
     self.db_cursor.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='key_log'"
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
     )
-    if self.db_cursor.fetchone() is not None:
+    return self.db_cursor.fetchone() is not None
+
+  def warn_about_legacy_sensitive_tables(self):
+    # Some sink tables hold history the current run neither writes nor protects:
+    # key_log (exact per-keystroke rows), full_key_log (exact up/down events +
+    # timestamps), and trigram_counts_agg (higher reconstruction risk than the
+    # default bigrams). When the matching opt-in flag is OFF, such a table is
+    # leftover from an older run -- not migrated, not read by the views, just
+    # sitting in the file and keeping that history reconstructable. The privacy
+    # default doesn't cover data written before the switch, so warn and point at
+    # the DROP. When the flag is ON the table is intentional this run, so skip
+    # it. Each table is gated only on its own flag (NOT on counts mode), so a
+    # leftover full_key_log/trigram table is still flagged under, e.g.,
+    # --no-counts --raw-events.
+    legacy_tables = (
+        ('key_log', self.config.send_raw_events_to_sqlite,
+         'exact per-keystroke rows; the exact typed sequence is recoverable'),
+        ('full_key_log', self.config.send_all_events_to_sqlite,
+         'exact key up/down events with timestamps'),
+        ('trigram_counts_agg', self.config.send_trigram_counts,
+         'trigram counts, a higher reconstruction risk than the default bigrams'),
+    )
+    for name, intentional, what_it_leaks in legacy_tables:
+      if intentional or not self.sqlite_table_exists(name):
+        continue
       logging.warning(
-          f"legacy 'key_log' table with exact keystrokes found in "
+          f"legacy '{name}' table ({what_it_leaks}) found in "
           f'{self.config.sqlite_file_name}; it is not migrated and stays on '
-          f'disk. Run "DROP TABLE key_log;" against the file to remove that '
-          f'history.'
+          f'disk. Run "DROP TABLE {name};" against the file to remove it.'
       )
 
   def create_sqlite_views(self):
@@ -863,7 +879,7 @@ class KeyLoggerApp:
       )
     self.prepare_sqlite_file()
     self.open_sqlite_connection()
-    self.warn_if_legacy_key_log_table()
+    self.warn_about_legacy_sensitive_tables()
     self.configure_sqlite_journal_mode()
     self.create_sqlite_tables()
     self.create_sqlite_views()

--- a/key_logger.py
+++ b/key_logger.py
@@ -779,6 +779,26 @@ class KeyLoggerApp:
       """)
       logging.debug('SQLite full_key_log table created')
 
+  def warn_if_legacy_key_log_table(self):
+    # A pre-existing key_log table holds exact per-keystroke rows from an older
+    # run. In counts-only mode it is neither migrated nor read by the views, so
+    # it just stays in the file and keeps that history reconstructable -- the
+    # privacy default doesn't cover data written before the switch. Warn so the
+    # user can drop it. (With --raw-events the table is intentional, not legacy.)
+    if (not self.config.send_counts_to_sqlite
+        or self.config.send_raw_events_to_sqlite):
+      return
+    self.db_cursor.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='key_log'"
+    )
+    if self.db_cursor.fetchone() is not None:
+      logging.warning(
+          f"legacy 'key_log' table with exact keystrokes found in "
+          f'{self.config.sqlite_file_name}; it is not migrated and stays on '
+          f'disk. Run "DROP TABLE key_log;" against the file to remove that '
+          f'history.'
+      )
+
   def create_sqlite_views(self):
     # The convenience views summarize the aggregate count tables. Without
     # counts there's nothing for them to read, so skip them in raw-only mode.
@@ -843,6 +863,7 @@ class KeyLoggerApp:
       )
     self.prepare_sqlite_file()
     self.open_sqlite_connection()
+    self.warn_if_legacy_key_log_table()
     self.configure_sqlite_journal_mode()
     self.create_sqlite_tables()
     self.create_sqlite_views()

--- a/key_logger.py
+++ b/key_logger.py
@@ -22,7 +22,7 @@ import sqlite3
 import stat
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pynput.keyboard import Key, KeyCode, Listener
 
@@ -31,7 +31,13 @@ from pynput.keyboard import Key, KeyCode, Listener
 # ######### User Settings ##########
 # ######### #### ######## ##########
 
+# SQLite is the master switch for using the database at all. Beneath it,
+# the aggregate count tables (the private default), the exact per-keystroke
+# `key_log` table, and the full up/down event log are independent sinks.
 DEFAULT_SEND_LOGS_TO_SQLITE = True
+DEFAULT_SEND_COUNTS_TO_SQLITE = True
+DEFAULT_SEND_RAW_EVENTS_TO_SQLITE = False
+DEFAULT_SEND_TRIGRAM_COUNTS = False
 DEFAULT_SEND_ALL_EVENTS_TO_SQLITE = False
 DEFAULT_SEND_LOGS_TO_FILE = False
 DEFAULT_ECHO_KEYS_TO_STDOUT = False
@@ -40,6 +46,11 @@ DEFAULT_LOG_PHYSICAL_KEYS = False
 DEFAULT_TIMESTAMP_FILE_LOGS = True
 DEFAULT_DISTINGUISH_MODIFIER_SIDES = False
 
+# Keystrokes are aggregated into counts grouped by this many minutes, so the
+# exact typed sequence (passwords included) is never stored, only per-bucket
+# tallies. See bucket_label() and the long comment in log().
+DEFAULT_BUCKET_MINUTES = 10
+
 DEFAULT_LOG_FILE_NAME = 'key_log.txt'
 DEFAULT_SQLITE_FILE_NAME = 'key_log.sqlite'
 DEFAULT_ENABLE_SQLITE_WAL = False
@@ -47,6 +58,14 @@ DEFAULT_ENABLE_SQLITE_WAL = False
 OWNER_ONLY_FILE_MODE = 0o600
 SQLITE_COMMIT_EVERY_N_EVENTS = 50
 SQLITE_COMMIT_EVERY_SECONDS = 5.0
+
+# A bigram is only counted when two keys are pressed within this many seconds
+# of each other; a longer pause breaks the chain so unrelated typing sessions
+# aren't stitched into spurious adjacency data.
+BIGRAM_IDLE_RESET_SECONDS = 2.0
+
+# UPSERT (INSERT ... ON CONFLICT ... DO UPDATE) requires SQLite 3.24+ (2018).
+MINIMUM_SQLITE_VERSION_FOR_UPSERT = (3, 24, 0)
 
 # ######### ####### ##### ##########
 # ######### Logging Setup ##########
@@ -120,13 +139,77 @@ SHIFTED_KEY_EQUIVALENTS = {
     '/': '?',
 }
 
+# Aggregate count tables. Each holds per-bucket tallies rather than one row
+# per keystroke, so the exact typed sequence is never recoverable. The
+# composite PRIMARY KEY is the conflict target the UPSERTs below increment.
+#
+# WITHOUT ROWID is load-bearing for privacy, not an optimization: an ordinary
+# table keeps an implicit rowid in INSERTION order, so reading the rows in
+# rowid order would replay the order keys/bigrams were first seen in a bucket
+# (the bigram rows alone trivially reconstruct a quiet-bucket password). A
+# WITHOUT ROWID table has no such column; rows live only in PRIMARY KEY
+# (lexicographic) order, which reveals nothing about typing order. Counts are
+# all that remain.
+KEY_COUNTS_AGG_TABLE_SQL = """
+  CREATE TABLE IF NOT EXISTS key_counts_agg (
+    bucket_utc TEXT NOT NULL,
+    key_code TEXT NOT NULL,
+    count INTEGER NOT NULL,
+    PRIMARY KEY (bucket_utc, key_code)
+  ) WITHOUT ROWID
+"""
+
+BIGRAM_COUNTS_AGG_TABLE_SQL = """
+  CREATE TABLE IF NOT EXISTS bigram_counts_agg (
+    bucket_utc TEXT NOT NULL,
+    key1 TEXT NOT NULL,
+    key2 TEXT NOT NULL,
+    count INTEGER NOT NULL,
+    PRIMARY KEY (bucket_utc, key1, key2)
+  ) WITHOUT ROWID
+"""
+
+TRIGRAM_COUNTS_AGG_TABLE_SQL = """
+  CREATE TABLE IF NOT EXISTS trigram_counts_agg (
+    bucket_utc TEXT NOT NULL,
+    key1 TEXT NOT NULL,
+    key2 TEXT NOT NULL,
+    key3 TEXT NOT NULL,
+    count INTEGER NOT NULL,
+    PRIMARY KEY (bucket_utc, key1, key2, key3)
+  ) WITHOUT ROWID
+"""
+
+INSERT_KEY_COUNT_SQL = (
+    'INSERT INTO key_counts_agg (bucket_utc, key_code, count) VALUES (?, ?, 1) '
+    'ON CONFLICT(bucket_utc, key_code) DO UPDATE SET count = count + 1'
+)
+
+INSERT_BIGRAM_COUNT_SQL = (
+    'INSERT INTO bigram_counts_agg (bucket_utc, key1, key2, count) '
+    'VALUES (?, ?, ?, 1) '
+    'ON CONFLICT(bucket_utc, key1, key2) DO UPDATE SET count = count + 1'
+)
+
+INSERT_TRIGRAM_COUNT_SQL = (
+    'INSERT INTO trigram_counts_agg (bucket_utc, key1, key2, key3, count) '
+    'VALUES (?, ?, ?, ?, 1) '
+    'ON CONFLICT(bucket_utc, key1, key2, key3) DO UPDATE SET count = count + 1'
+)
+
+# The views below summarize the aggregate tables across all buckets. They keep
+# the same output columns (count, frequency, cumulative_frequency) the old
+# key_log-based views had, so existing analysis queries keep working. Combo
+# filtering (the old `NOT LIKE '%+%'`) now happens at capture time, so it isn't
+# repeated here.
 KEY_COUNTS_VIEW_SQL = """
   CREATE VIEW IF NOT EXISTS key_counts AS
   WITH frequencies AS (
-      SELECT key_code, count(*) AS count,
-          (count(*) * 1.0) / (SELECT count(*) FROM key_log) AS frequency
-      FROM key_log
-      GROUP BY 1
+      SELECT key_code, SUM(count) AS count,
+          (SUM(count) * 1.0) / (SELECT SUM(count) FROM key_counts_agg)
+              AS frequency
+      FROM key_counts_agg
+      GROUP BY key_code
   )
   SELECT *, SUM(frequency) OVER (
       ORDER BY frequency DESC ROWS UNBOUNDED PRECEDING
@@ -137,79 +220,48 @@ KEY_COUNTS_VIEW_SQL = """
 
 BIGRAM_COUNTS_VIEW_SQL = """
   CREATE VIEW IF NOT EXISTS bigram_counts AS
-  WITH raw_bigram_data AS
-  (
-    SELECT key_code, lag(key_code) OVER (ORDER BY time_utc) AS key_code_lag_1
-    FROM key_log
+  WITH bigram_totals AS (
+      SELECT key1 || ' ' || key2 AS bigram, SUM(count) AS count
+      FROM bigram_counts_agg
+      GROUP BY key1, key2
   )
-  , bigram_counts AS
-  (
-    SELECT key_code_lag_1 || ' ' || key_code AS bigram, count(*) AS count
-    FROM raw_bigram_data
-    WHERE true
-      AND key_code IS NOT NULL
-      AND key_code_lag_1 IS NOT NULL
-      AND key_code NOT LIKE '%+%'
-      AND key_code_lag_1 NOT LIKE '%+%'
-    GROUP BY 1
-  )
-  , bigram_frequencies AS
-  (
-    SELECT *,
-      (1.0* count ) / (SELECT sum(count) FROM bigram_counts) AS frequency
-    FROM bigram_counts
+  , bigram_frequencies AS (
+      SELECT bigram, count,
+          (1.0 * count) / (SELECT SUM(count) FROM bigram_totals) AS frequency
+      FROM bigram_totals
   )
   SELECT *, SUM(frequency) OVER (
       ORDER BY frequency DESC ROWS UNBOUNDED PRECEDING
   ) AS cumulative_frequency
   FROM bigram_frequencies
-  GROUP BY bigram
   ORDER BY cumulative_frequency, count DESC, bigram
 """
 
 TRIGRAM_COUNTS_VIEW_SQL = """
   CREATE VIEW IF NOT EXISTS trigram_counts AS
-  WITH raw_trigram_data AS
-  (
-    SELECT
-      key_code,
-      lag(key_code) OVER (ORDER BY time_utc) AS key_code_lag_1,
-      lag(key_code, 2) OVER (ORDER BY time_utc) AS key_code_lag_2
-    FROM key_log
+  WITH trigram_totals AS (
+      SELECT key1 || ' ' || key2 || ' ' || key3 AS trigram, SUM(count) AS count
+      FROM trigram_counts_agg
+      GROUP BY key1, key2, key3
   )
-  , trigram_counts AS
-  (
-    SELECT
-      key_code_lag_2 || ' ' || key_code_lag_1 || ' ' || key_code AS trigram,
-      count(*) AS count
-    FROM raw_trigram_data
-    WHERE true
-      AND key_code IS NOT NULL
-      AND key_code_lag_1 IS NOT NULL
-      AND key_code_lag_2 IS NOT NULL
-      AND key_code NOT LIKE '%+%'
-      AND key_code_lag_1 NOT LIKE '%+%'
-      AND key_code_lag_2 NOT LIKE '%+%'
-    GROUP BY 1
-  )
-  , trigram_frequencies AS
-  (
-    SELECT *,
-      (1.0* count ) / (SELECT sum(count) FROM trigram_counts) AS frequency
-    FROM trigram_counts
+  , trigram_frequencies AS (
+      SELECT trigram, count,
+          (1.0 * count) / (SELECT SUM(count) FROM trigram_totals) AS frequency
+      FROM trigram_totals
   )
   SELECT *, SUM(frequency) OVER (
       ORDER BY frequency DESC ROWS UNBOUNDED PRECEDING
   ) AS cumulative_frequency
   FROM trigram_frequencies
-  GROUP BY trigram
   ORDER BY cumulative_frequency, count DESC, trigram
 """
 
 
 @dataclass
 class Config:
-  send_logs_to_sqlite: bool = DEFAULT_SEND_LOGS_TO_SQLITE
+  send_counts_to_sqlite: bool = DEFAULT_SEND_COUNTS_TO_SQLITE
+  send_raw_events_to_sqlite: bool = DEFAULT_SEND_RAW_EVENTS_TO_SQLITE
+  send_trigram_counts: bool = DEFAULT_SEND_TRIGRAM_COUNTS
   send_all_events_to_sqlite: bool = DEFAULT_SEND_ALL_EVENTS_TO_SQLITE
   send_logs_to_file: bool = DEFAULT_SEND_LOGS_TO_FILE
   timestamp_file_logs: bool = DEFAULT_TIMESTAMP_FILE_LOGS
@@ -220,6 +272,18 @@ class Config:
   log_file_name: str = DEFAULT_LOG_FILE_NAME
   sqlite_file_name: str = DEFAULT_SQLITE_FILE_NAME
   enable_sqlite_wal: bool = DEFAULT_ENABLE_SQLITE_WAL
+  bucket_interval_seconds: int = DEFAULT_BUCKET_MINUTES * 60
+
+  @property
+  def uses_sqlite(self):
+    # True when any SQLite-backed sink is on, so the database is opened and
+    # commits are flushed. The --sqlite/--no-sqlite master switch is resolved
+    # into these fields in parse_args().
+    return (
+        self.send_counts_to_sqlite
+        or self.send_raw_events_to_sqlite
+        or self.send_all_events_to_sqlite
+    )
 
 
 # `Config` holds the user-selected runtime settings derived from CLI flags.
@@ -235,13 +299,56 @@ def build_parser():
       '--sqlite',
       dest='send_logs_to_sqlite',
       action='store_true',
-      help='write the main key log to SQLite'
+      help='use the SQLite database (master switch for all DB sinks)'
   )
   parser.add_argument(
       '--no-sqlite',
       dest='send_logs_to_sqlite',
       action='store_false',
-      help='disable the main SQLite key log'
+      help='disable the SQLite database entirely'
+  )
+  parser.add_argument(
+      '--counts',
+      dest='send_counts_to_sqlite',
+      action='store_true',
+      help='write aggregate key/bigram counts bucketed by time (default: follows --sqlite)'
+  )
+  parser.add_argument(
+      '--no-counts',
+      dest='send_counts_to_sqlite',
+      action='store_false',
+      help='disable the aggregate count tables'
+  )
+  parser.add_argument(
+      '--raw-events',
+      dest='send_raw_events_to_sqlite',
+      action='store_true',
+      help='also store exact per-keystroke rows in key_log (less private; off by default)'
+  )
+  parser.add_argument(
+      '--no-raw-events',
+      dest='send_raw_events_to_sqlite',
+      action='store_false',
+      help='disable the exact per-keystroke key_log table'
+  )
+  parser.add_argument(
+      '--trigrams',
+      dest='send_trigram_counts',
+      action='store_true',
+      help='also aggregate trigram counts (off by default; increases reconstruction risk)'
+  )
+  parser.add_argument(
+      '--no-trigrams',
+      dest='send_trigram_counts',
+      action='store_false',
+      help='disable trigram aggregation'
+  )
+  parser.add_argument(
+      '--bucket-minutes',
+      dest='bucket_minutes',
+      type=int,
+      default=DEFAULT_BUCKET_MINUTES,
+      help='size in minutes of the aggregation time bucket'
   )
   parser.add_argument(
       '--file',
@@ -322,6 +429,10 @@ def build_parser():
   )
   parser.set_defaults(
       send_logs_to_sqlite=DEFAULT_SEND_LOGS_TO_SQLITE,
+      # None means "follow the --sqlite master switch"; resolved in parse_args.
+      send_counts_to_sqlite=None,
+      send_raw_events_to_sqlite=DEFAULT_SEND_RAW_EVENTS_TO_SQLITE,
+      send_trigram_counts=DEFAULT_SEND_TRIGRAM_COUNTS,
       send_logs_to_file=DEFAULT_SEND_LOGS_TO_FILE,
       send_all_events_to_sqlite=DEFAULT_SEND_ALL_EVENTS_TO_SQLITE,
       file_timestamps=DEFAULT_TIMESTAMP_FILE_LOGS,
@@ -334,11 +445,38 @@ def parse_args(argv=None):
   parser = build_parser()
   args = parser.parse_args(argv)
 
-  if args.send_all_events_to_sqlite and not args.send_logs_to_sqlite:
-    parser.error('--full-events requires SQLite logging; remove --no-sqlite')
+  # Counts default to following the --sqlite master switch unless the user
+  # explicitly passed --counts/--no-counts.
+  send_counts = args.send_counts_to_sqlite
+  if send_counts is None:
+    send_counts = args.send_logs_to_sqlite
+
+  if args.bucket_minutes <= 0:
+    parser.error('--bucket-minutes must be a positive integer')
+
+  db_sinks_on = (
+      send_counts
+      or args.send_raw_events_to_sqlite
+      or args.send_all_events_to_sqlite
+  )
+  if db_sinks_on and not args.send_logs_to_sqlite:
+    parser.error(
+        'count/raw-event/full-event logging requires SQLite; remove --no-sqlite'
+    )
+
+  if args.send_trigram_counts and not send_counts:
+    parser.error('--trigrams requires count aggregation; enable counts')
+
+  if not (db_sinks_on or args.send_logs_to_file or args.stdout):
+    parser.error(
+        'no output sink enabled; enable counts, --raw-events, --full-events, '
+        '--file, or --stdout'
+    )
 
   return Config(
-      send_logs_to_sqlite=args.send_logs_to_sqlite,
+      send_counts_to_sqlite=send_counts,
+      send_raw_events_to_sqlite=args.send_raw_events_to_sqlite,
+      send_trigram_counts=args.send_trigram_counts,
       send_all_events_to_sqlite=args.send_all_events_to_sqlite,
       send_logs_to_file=args.send_logs_to_file,
       timestamp_file_logs=args.file_timestamps,
@@ -349,6 +487,7 @@ def parse_args(argv=None):
       log_file_name=args.log_file,
       sqlite_file_name=args.sqlite_file,
       enable_sqlite_wal=args.enable_sqlite_wal,
+      bucket_interval_seconds=args.bucket_minutes * 60,
   )
 
 
@@ -464,6 +603,26 @@ def equivalent_shifted_keys(key):
   return equivalents
 
 
+def bucket_label(dt, interval_seconds=600):
+  """
+  Floor a UTC datetime down to the start of its time bucket and return it as
+  an ISO-8601 string. interval_seconds defaults to 600 (10 minutes).
+
+  Flooring (not rounding to the nearest boundary) means a bucket label is a
+  real timestamp marking the inclusive start of the window it covers, buckets
+  never overlap, and every event maps to exactly one bucket deterministically.
+  This is the grouping key the aggregate count tables use, so individual
+  keystroke timings are discarded — only per-bucket tallies remain.
+  """
+  epoch = int(dt.replace(tzinfo=timezone.utc).timestamp())
+  floored = epoch - (epoch % interval_seconds)
+  return (
+      datetime.fromtimestamp(floored, timezone.utc)
+      .replace(tzinfo=None)
+      .isoformat()
+  )
+
+
 class KeyLoggerApp:
   # `KeyLoggerApp` owns the mutable state and side effects of a single run.
   def __init__(self, config):
@@ -474,6 +633,13 @@ class KeyLoggerApp:
     self.db_connection = None
     self.db_cursor = None
     self._close_registered = False
+    # Capture-time n-gram chain. Bigrams/trigrams are formed from the last
+    # one/two logged "plain" entries, then stored as counts. The chain resets
+    # across modifier combos, long pauses, and bucket boundaries (see log()).
+    self.previous_logged_entry = None
+    self.previous_logged_monotonic = None
+    self.previous_logged_bucket = None
+    self.second_previous_logged_entry = None
 
   def get_file_mode(self, path):
     return stat.S_IMODE(os.stat(path).st_mode)
@@ -509,7 +675,7 @@ class KeyLoggerApp:
     return os.fdopen(fd, 'a')
 
   def commit_sqlite_if_needed(self, force=False):
-    if not self.config.send_logs_to_sqlite or self.pending_sqlite_writes == 0:
+    if not self.config.uses_sqlite or self.pending_sqlite_writes == 0:
       return
 
     elapsed_since_last_commit = (
@@ -591,11 +757,20 @@ class KeyLoggerApp:
     logging.info('SQLite WAL mode enabled')
 
   def create_sqlite_tables(self):
-    self.db_cursor.execute("""
-        CREATE TABLE IF NOT EXISTS key_log
-        (time_utc TEXT, key_code TEXT)
-    """)
-    logging.debug('SQLite key_log table created')
+    if self.config.send_counts_to_sqlite:
+      self.db_cursor.execute(KEY_COUNTS_AGG_TABLE_SQL)
+      self.db_cursor.execute(BIGRAM_COUNTS_AGG_TABLE_SQL)
+      logging.debug('SQLite key_counts_agg and bigram_counts_agg tables created')
+      if self.config.send_trigram_counts:
+        self.db_cursor.execute(TRIGRAM_COUNTS_AGG_TABLE_SQL)
+        logging.debug('SQLite trigram_counts_agg table created')
+
+    if self.config.send_raw_events_to_sqlite:
+      self.db_cursor.execute("""
+          CREATE TABLE IF NOT EXISTS key_log
+          (time_utc TEXT, key_code TEXT)
+      """)
+      logging.debug('SQLite key_log table created')
 
     if self.config.send_all_events_to_sqlite:
       self.db_cursor.execute("""
@@ -605,6 +780,11 @@ class KeyLoggerApp:
       logging.debug('SQLite full_key_log table created')
 
   def create_sqlite_views(self):
+    # The convenience views summarize the aggregate count tables. Without
+    # counts there's nothing for them to read, so skip them in raw-only mode.
+    if not self.config.send_counts_to_sqlite:
+      return
+
     self.db_cursor.execute('DROP VIEW IF EXISTS key_counts')
     self.db_cursor.execute(KEY_COUNTS_VIEW_SQL)
     logging.debug('SQLite key_counts view created')
@@ -613,9 +793,12 @@ class KeyLoggerApp:
     self.db_cursor.execute(BIGRAM_COUNTS_VIEW_SQL)
     logging.debug('SQLite bigram_counts view created')
 
+    # Always drop the trigram view so an old one doesn't dangle; recreate it
+    # only when trigram aggregation is enabled.
     self.db_cursor.execute('DROP VIEW IF EXISTS trigram_counts')
-    self.db_cursor.execute(TRIGRAM_COUNTS_VIEW_SQL)
-    logging.debug('SQLite trigram_counts view created')
+    if self.config.send_trigram_counts:
+      self.db_cursor.execute(TRIGRAM_COUNTS_VIEW_SQL)
+      logging.debug('SQLite trigram_counts view created')
 
   def finish_sqlite_setup(self):
     self.db_connection.commit()
@@ -642,11 +825,22 @@ class KeyLoggerApp:
     will be created, or (3) change the name of the file in the
     sqlite_file_name config value and a new one will be created.
 
-    There's a few views that are created, simply as a convenience, that
-    will list your usage by key, bi-gram, and tri-gram. The main table
-    keeps a single row for every key-stroke, which doesn't do much for the
-    ultimate goal of understanding your aggregate key usage.
+    By default the database stores only AGGREGATE COUNTS grouped into time
+    buckets (see DEFAULT_BUCKET_MINUTES and bucket_label): one row per
+    (bucket, key) and (bucket, key1, key2), incremented in place. The exact
+    typed sequence is never written, so passwords can't be read back out of
+    the file. The convenience views (key_counts, bigram_counts, and, with
+    --trigrams, trigram_counts) summarize those tallies for layout analysis.
+    Trigrams and the exact per-keystroke `key_log` table (--raw-events) are
+    opt-in and off by default because they leak more ordering information.
     """
+    if (self.config.send_counts_to_sqlite
+        and sqlite3.sqlite_version_info < MINIMUM_SQLITE_VERSION_FOR_UPSERT):
+      raise SystemExit(
+          f'SQLite {sqlite3.sqlite_version} is too old for count aggregation; '
+          'need >= 3.24.0 for UPSERT. Upgrade Python/SQLite, or run with '
+          '--no-counts --raw-events for the exact-sequence log instead.'
+      )
     self.prepare_sqlite_file()
     self.open_sqlite_connection()
     self.configure_sqlite_journal_mode()
@@ -712,9 +906,15 @@ class KeyLoggerApp:
     if self.config.echo_keys_to_stdout:
       logging.info(f'key: {log_entry}')
 
-    timestamp_utc = datetime.utcnow().isoformat()
+    now_dt = datetime.now(timezone.utc)
+    timestamp_utc = now_dt.replace(tzinfo=None).isoformat()
 
-    if self.config.send_logs_to_sqlite:
+    if self.config.send_counts_to_sqlite:
+      bucket = bucket_label(now_dt, self.config.bucket_interval_seconds)
+      self.record_unigram_count(bucket, log_entry)
+      self.update_ngram_chain(bucket, log_entry, time.monotonic())
+
+    if self.config.send_raw_events_to_sqlite:
       row_values = (timestamp_utc, log_entry)
       self.db_cursor.execute(
           'INSERT INTO key_log VALUES (?, ?)',
@@ -731,10 +931,70 @@ class KeyLoggerApp:
         log_file.write(f'{file_entry}\n')
         logging.debug(f'logged to file: {log_entry}')
 
+  def record_unigram_count(self, bucket, key_str):
+    self.db_cursor.execute(INSERT_KEY_COUNT_SQL, (bucket, key_str))
+    self.note_pending_sqlite_write()
+
+  def record_bigram_count(self, bucket, key1, key2):
+    self.db_cursor.execute(INSERT_BIGRAM_COUNT_SQL, (bucket, key1, key2))
+    self.note_pending_sqlite_write()
+
+  def record_trigram_count(self, bucket, key1, key2, key3):
+    self.db_cursor.execute(INSERT_TRIGRAM_COUNT_SQL, (bucket, key1, key2, key3))
+    self.note_pending_sqlite_write()
+
+  def update_ngram_chain(self, bucket, log_entry, now_monotonic):
+    """
+    Count the bigram (and, if enabled, trigram) ending at this keystroke, then
+    advance the chain. This replaces the old SQL views that rebuilt n-grams
+    from consecutive per-keystroke rows: since we no longer store those rows,
+    adjacency has to be captured live.
+
+    A pair is only counted when both keys are "plain" (no modifier combo, i.e.
+    no ' + ' in the entry, mirroring the old views' NOT LIKE '%+%' filter),
+    pressed within BIGRAM_IDLE_RESET_SECONDS of each other, and falling in the
+    same time bucket. The bucket guard keeps each stored row internally
+    consistent (a bigram never spans two buckets); a combo, a long pause, or a
+    bucket flip simply breaks the chain and it reseeds on the next plain key.
+    """
+    current_is_plain = ' + ' not in log_entry
+    bigram_emitted = False
+
+    if (current_is_plain
+        and self.previous_logged_entry is not None
+        and (now_monotonic - self.previous_logged_monotonic)
+            <= BIGRAM_IDLE_RESET_SECONDS
+        and bucket == self.previous_logged_bucket):
+      self.record_bigram_count(bucket, self.previous_logged_entry, log_entry)
+      bigram_emitted = True
+      if (self.config.send_trigram_counts
+          and self.second_previous_logged_entry is not None):
+        self.record_trigram_count(
+            bucket,
+            self.second_previous_logged_entry,
+            self.previous_logged_entry,
+            log_entry
+        )
+
+    if current_is_plain:
+      # second_previous stays valid only when this step formed a real
+      # consecutive pair; otherwise a trigram next step would span a break.
+      self.second_previous_logged_entry = (
+          self.previous_logged_entry if bigram_emitted else None
+      )
+      self.previous_logged_entry = log_entry
+      self.previous_logged_monotonic = now_monotonic
+      self.previous_logged_bucket = bucket
+    else:
+      self.second_previous_logged_entry = None
+      self.previous_logged_entry = None
+      self.previous_logged_monotonic = None
+      self.previous_logged_bucket = None
+
   def full_log(self, key, event):
     if self.config.send_all_events_to_sqlite:
       row_values = (
-          datetime.utcnow().isoformat(),
+          datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
           key_to_str(canonicalize_key(
               key,
               self.config.distinguish_modifier_sides
@@ -890,7 +1150,10 @@ class KeyLoggerApp:
     logging.info('getting set up')
     logging.info(
         'effective config: '
-        f'sqlite={"on" if self.config.send_logs_to_sqlite else "off"}, '
+        f'counts={"on" if self.config.send_counts_to_sqlite else "off"}, '
+        f'bucket_minutes={self.config.bucket_interval_seconds // 60}, '
+        f'trigrams={"on" if self.config.send_trigram_counts else "off"}, '
+        f'raw_events={"on" if self.config.send_raw_events_to_sqlite else "off"}, '
         f'full_events={"on" if self.config.send_all_events_to_sqlite else "off"}, '
         f'file={"on" if self.config.send_logs_to_file else "off"}, '
         f'file_timestamps={"on" if self.config.timestamp_file_logs else "off"}, '
@@ -905,7 +1168,7 @@ class KeyLoggerApp:
         f'sqlite={self.config.sqlite_file_name}, '
         f'file={self.config.log_file_name}'
     )
-    if self.config.send_logs_to_sqlite:
+    if self.config.uses_sqlite:
       self.setup_sqlite_database()
 
     with Listener(

--- a/launchd/install.sh
+++ b/launchd/install.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+#
+# install.sh -- generate and load the benign-key-logger macOS LaunchAgent so the
+# logger starts automatically at login.
+#
+# What it does, in plain terms (read before running):
+#   1. Fills the absolute paths into the .plist.template next to this script.
+#   2. Writes the result to ~/Library/LaunchAgents/<Label>.plist.
+#   3. Validates it with `plutil -lint`.
+#   4. Loads it with `launchctl bootstrap` (and unloads any previous copy first).
+#
+# It does NOT touch key_logger.py, does NOT grant any permission for you, and
+# sends nothing anywhere. Re-running it is safe (idempotent re-install).
+#
+# Override the interpreter with PYTHON_OVERRIDE=/path/to/python if your env
+# lives somewhere other than the default conda location below.
+
+set -eu
+
+# --- Configuration (edit if you want a different label) ---------------------
+LABEL="local.benign-key-logger"
+DEFAULT_PYTHON="$HOME/opt/miniconda3/envs/keylogger/bin/python"
+
+# --- Resolve locations ------------------------------------------------------
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+TEMPLATE="$SCRIPT_DIR/$LABEL.plist.template"
+PLIST_DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG_DIR="$HOME/Library/Logs/benign-key-logger"
+DB="$REPO_DIR/key_log.sqlite"
+
+PYTHON="${PYTHON_OVERRIDE:-$DEFAULT_PYTHON}"
+
+# --- Sanity checks ----------------------------------------------------------
+if [ ! -f "$TEMPLATE" ]; then
+  echo "error: template not found at $TEMPLATE" >&2
+  exit 1
+fi
+if [ ! -x "$PYTHON" ]; then
+  echo "error: python interpreter not found/executable at: $PYTHON" >&2
+  echo "       set PYTHON_OVERRIDE=/path/to/python and re-run." >&2
+  exit 1
+fi
+
+# The TCC (Input Monitoring / Accessibility) grant attaches to the RESOLVED real
+# binary, not the symlink we invoke -- report that path so the user grants the
+# right thing.
+REAL_PYTHON=$("$PYTHON" -c 'import os, sys; print(os.path.realpath(sys.executable))')
+
+# --- Generate the concrete plist from the template --------------------------
+mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
+
+sed \
+  -e "s|__LABEL__|$LABEL|g" \
+  -e "s|__PYTHON__|$PYTHON|g" \
+  -e "s|__SCRIPT__|$REPO_DIR/key_logger.py|g" \
+  -e "s|__WORKDIR__|$REPO_DIR|g" \
+  -e "s|__DB__|$DB|g" \
+  -e "s|__STDOUT_LOG__|$LOG_DIR/launchd.out.log|g" \
+  -e "s|__STDERR_LOG__|$LOG_DIR/launchd.err.log|g" \
+  "$TEMPLATE" > "$PLIST_DEST"
+chmod 0644 "$PLIST_DEST"
+
+# --- Validate ---------------------------------------------------------------
+plutil -lint "$PLIST_DEST"
+
+# --- (Re)load ---------------------------------------------------------------
+# Unload any previous copy first so this is a clean, repeatable install.
+launchctl bootout "gui/$(id -u)" "$PLIST_DEST" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
+
+# --- Report + the one manual step we cannot do for you ----------------------
+echo ""
+echo "Installed and loaded: $LABEL"
+echo "  plist : $PLIST_DEST"
+echo "  db    : $DB"
+echo "  logs  : $LOG_DIR/launchd.{out,err}.log"
+echo ""
+echo "REQUIRED MANUAL STEP -- grant keyboard access, or it captures nothing:"
+echo "  System Settings > Privacy & Security > Input Monitoring  (and, if that"
+echo "  alone does not work, also Accessibility) > click '+' > press Cmd+Shift+G"
+echo "  and paste this exact path, then enable the toggle:"
+echo ""
+echo "    $REAL_PYTHON"
+echo ""
+echo "macOS does NOT prompt for this automatically when launchd starts the agent,"
+echo "and pynput fails silently without it. Verify capture by typing for a bit,"
+echo "then checking the database grows:"
+echo "  sqlite3 \"$DB\" \"SELECT COALESCE(SUM(count),0) FROM key_counts_agg;\""
+echo ""
+echo "Status:   launchctl print \"gui/$(id -u)/$LABEL\""
+echo "Stop it:  sh \"$SCRIPT_DIR/uninstall.sh\""

--- a/launchd/install.sh
+++ b/launchd/install.sh
@@ -48,18 +48,33 @@ fi
 REAL_PYTHON=$("$PYTHON" -c 'import os, sys; print(os.path.realpath(sys.executable))')
 
 # --- Generate the concrete plist from the template --------------------------
+# Fill the template with plutil (already used for -lint below), NOT raw sed.
+# plutil writes through the plist serializer, so values containing characters
+# that are significant to XML or to sed (& < > " | \) are stored literally and
+# escaped correctly -- raw `sed` substitution would corrupt the XML or mangle
+# the replacement on such a path. Scalars go in by key; the whole
+# ProgramArguments array is replaced in one shot via a JSON value built by the
+# resolved interpreter, so every argv element is escaped safely too. (Note:
+# `plutil -replace ProgramArguments.<N>` would INSERT at N, not overwrite it.)
 mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
-
-sed \
-  -e "s|__LABEL__|$LABEL|g" \
-  -e "s|__PYTHON__|$PYTHON|g" \
-  -e "s|__SCRIPT__|$REPO_DIR/key_logger.py|g" \
-  -e "s|__WORKDIR__|$REPO_DIR|g" \
-  -e "s|__DB__|$DB|g" \
-  -e "s|__STDOUT_LOG__|$LOG_DIR/launchd.out.log|g" \
-  -e "s|__STDERR_LOG__|$LOG_DIR/launchd.err.log|g" \
-  "$TEMPLATE" > "$PLIST_DEST"
+cp "$TEMPLATE" "$PLIST_DEST"
 chmod 0644 "$PLIST_DEST"
+
+plutil -replace Label             -string "$LABEL"                    "$PLIST_DEST"
+plutil -replace WorkingDirectory  -string "$REPO_DIR"                 "$PLIST_DEST"
+plutil -replace StandardOutPath   -string "$LOG_DIR/launchd.out.log"  "$PLIST_DEST"
+plutil -replace StandardErrorPath -string "$LOG_DIR/launchd.err.log"  "$PLIST_DEST"
+
+PA_JSON=$("$PYTHON" -c 'import json, sys; print(json.dumps([sys.argv[1], sys.argv[2], "--sqlite-file", sys.argv[3]]))' \
+  "$PYTHON" "$REPO_DIR/key_logger.py" "$DB")
+plutil -replace ProgramArguments -json "$PA_JSON" "$PLIST_DEST"
+
+# A mistyped keypath would leave a placeholder behind that `plutil -lint` still
+# accepts (it's valid XML), shipping a broken agent silently. Fail loud instead.
+if grep -q '__[A-Z_]*__' "$PLIST_DEST"; then
+  echo "error: unsubstituted placeholder remains in $PLIST_DEST" >&2
+  exit 1
+fi
 
 # --- Validate ---------------------------------------------------------------
 plutil -lint "$PLIST_DEST"

--- a/launchd/local.benign-key-logger.plist.template
+++ b/launchd/local.benign-key-logger.plist.template
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LaunchAgent template for benign-key-logger.
+
+  This is a TEMPLATE, not the file launchd loads. The placeholder tokens are
+  filled in with absolute paths by launchd/install.sh, which writes the result to
+  ~/Library/LaunchAgents/<Label>.plist. Edit THIS file (then re-run install.sh)
+  to change how the background logger runs; do not hand-edit the installed copy.
+
+  This is a user LaunchAgent (it lives in ~/Library/LaunchAgents and loads into
+  the gui/<uid> domain), NOT a LaunchDaemon. That is deliberate: a daemon runs
+  outside your logged-in GUI session and would capture no keyboard events.
+
+  It runs key_logger.py with the privacy-preserving defaults (aggregate counts
+  only -- no --stdout, no --raw-events, no --trigrams), so the background run is
+  exactly as benign as a normal foreground run.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>__LABEL__</string>
+
+  <!-- Absolute paths: launchd runs with cwd=/, so the DB path MUST be absolute
+       or it would be written to /key_log.sqlite. WorkingDirectory below is a
+       belt-and-suspenders backup for the same reason. -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>__PYTHON__</string>
+    <string>__SCRIPT__</string>
+    <string>--sqlite-file</string>
+    <string>__DB__</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__WORKDIR__</string>
+
+  <!-- Start automatically at login. -->
+  <key>RunAtLoad</key>
+  <true/>
+
+  <!-- Restart only on an abnormal exit, not on a clean logout/shutdown.
+       NOTE: this does NOT rescue the "no Input Monitoring permission" case --
+       pynput keeps running and simply receives zero events, which is not a
+       crash. Confirm capture by checking that the database grows. -->
+  <key>KeepAlive</key>
+  <dict>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+
+  <!-- Flush the startup summary promptly so the log below is useful. -->
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+
+  <!-- Operational status only (the effective-config summary and "starting to
+       listen" line, which the script logs to stderr). Captured keystrokes are
+       NOT echoed here -- stdout echo is off by default. -->
+  <key>StandardOutPath</key>
+  <string>__STDOUT_LOG__</string>
+  <key>StandardErrorPath</key>
+  <string>__STDERR_LOG__</string>
+</dict>
+</plist>

--- a/launchd/uninstall.sh
+++ b/launchd/uninstall.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# uninstall.sh -- stop and remove the benign-key-logger LaunchAgent.
+#
+# It unloads the agent and deletes the installed plist. It does NOT delete your
+# captured data (the SQLite database is left exactly where it is), and it does
+# not change any System Settings permissions.
+
+set -eu
+
+LABEL="local.benign-key-logger"
+PLIST_DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+# Unload if currently loaded (ignore the error if it is not).
+launchctl bootout "gui/$(id -u)" "$PLIST_DEST" 2>/dev/null || true
+
+if [ -f "$PLIST_DEST" ]; then
+  rm -f "$PLIST_DEST"
+  echo "Removed $PLIST_DEST and unloaded $LABEL."
+else
+  echo "$LABEL was not installed (no plist at $PLIST_DEST); nothing to remove."
+fi
+
+echo ""
+echo "Your captured data was left untouched."
+echo "To fully revoke keyboard access, remove the python interpreter from"
+echo "System Settings > Privacy & Security > Input Monitoring (and Accessibility)."


### PR DESCRIPTION
Two independent additions, both keeping the single-file, local-only, benign posture: no new dependencies, no network, and invasive modes stay opt-in and off by default.

Should address #14 — storing the exact key sequence means a leaked SQLite file can reveal passwords. This makes counts-only aggregation the default, so that risk is gone unless a user explicitly opts back in.

## Privacy-preserving default storage

- Default sink is now per-bucket aggregate counts, not one row per keystroke, so the exact typed sequence (passwords included) is never written to disk.
- Keystrokes are floored into time buckets (`--bucket-minutes`, default 10) and counted via SQLite UPSERT into `key_counts_agg` / `bigram_counts_agg`.
- Those tables are `WITHOUT ROWID`, so insertion/typing order isn't recoverable — only counts remain. (Rounding timestamps alone protects nothing; rows stay recoverable in rowid order. This is the actual fix.)
- Bigrams (and optional trigrams) are counted at capture time, since they can't be rebuilt from stored rows anymore. The chain breaks across modifier combos, idle pauses, and bucket boundaries.
- The convenience views (`key_counts`, `bigram_counts`, ...) were rewritten to read the aggregate tables, so existing queries keep working.
- **Backwards compatible — the previous behavior is fully restorable via opt-in flags, all off by default.** `--raw-events` brings back the old exact per-keystroke `key_log` table (the prior default), and `--trigrams` re-adds trigram counts (more reconstruction-prone than bigrams, hence off). Nothing invasive is enabled unless you ask for it. `--sqlite` is the master DB switch; `--counts/--no-counts` and `--bucket-minutes` tune the new default.
- Also fixes the `datetime.utcnow()` deprecation and a bug where a literally-typed `+` was excluded from bigrams.
- Caveat (documented in the README): a short secret typed in an otherwise-quiet bucket keeps some bigram-reconstruction risk; mitigated by bucket mixing, chain breaks, and Secure Input Mode, not eliminated.

## macOS auto-start (LaunchAgent)

- New `launchd/` tooling to run the logger at login: a plist template plus `install.sh` / `uninstall.sh`. `key_logger.py` is untouched — no `launchctl`/`subprocess` in the auditable file.
- The plist uses placeholder tokens (no machine-specific paths in the repo); `install.sh` fills them from `$HOME` and the repo location, lints with `plutil`, and loads via `launchctl bootstrap gui/$(id -u)` (idempotent). Interpreter path is overridable with `PYTHON_OVERRIDE`.
- Runs with the privacy defaults only (counts-only; no `--stdout`/`--raw-events`/`--trigrams`) and an absolute DB path so it never lands in `/`.
- It's a user LaunchAgent in `gui/<uid>`, not a LaunchDaemon — a daemon runs outside the GUI session and would capture nothing.
- The README documents install/verify/uninstall and the one unavoidable manual step: granting Input Monitoring to the resolved interpreter binary (macOS doesn't prompt for launchd-started processes, and pynput fails silently without it).

Each change has a rationale doc under `.agents/commits/2026-06-08_*`, following the repo's existing convention.
